### PR TITLE
add: NPO Hub Open Sesame RSS feed

### DIFF
--- a/list.csv
+++ b/list.csv
@@ -1,2 +1,3 @@
 id,maintainer,created_at,url
 jothon,ronnywang,2024-05-05,https://jothon.g0v.tw
+npo_hub_open_sesame,yellowsoar,2024-05-11,https://rss-bridge.org/bridge01/?action=display&bridge=FilterBridge&url=https%3A%2F%2Fg0v-slack-archive.g0v.ronny.tw%2Findex%2Frss%2FC0385B90D&filter=.*希望有人來開門.*&filter_type=permit&case_insensitive=on&fix_encoding=on&target_content=on&title_from_content=on&length_limit=-1&format=Atom


### PR DESCRIPTION
## Why?

解決 IFTTT 設定時會判斷 rss-bridge 的網址為 `Not a valid URL`

## Reference

### rss-bridge filter setting

![2024-05-11_19-05-25](https://github.com/g0v/s.g0v.tw/assets/4775704/4da5a0c8-82fd-4952-8228-1444d5f33fa5)

### Before rss-bridge filter

https://rss-bridge.org/bridge01/?action=display&bridge=FilterBridge&url=https%3A%2F%2Fg0v-slack-archive.g0v.ronny.tw%2Findex%2Frss%2FC0385B90D&filter=.*&filter_type=permit&case_insensitive=on&fix_encoding=on&target_content=on&length_limit=-1&format=Html

### After rss-bridge filter

https://rss-bridge.org/bridge01/?action=display&bridge=FilterBridge&url=https%3A%2F%2Fg0v-slack-archive.g0v.ronny.tw%2Findex%2Frss%2FC0385B90D&filter=.*希望有人來開門.*&filter_type=permit&case_insensitive=on&fix_encoding=on&target_content=on&title_from_content=on&length_limit=-1&format=Html